### PR TITLE
detecting chained ops on disappeared elements and erroring appropriately

### DIFF
--- a/src/main/java/org/seleniumhq/selenium/fluent/BaseFluentWebDriver.java
+++ b/src/main/java/org/seleniumhq/selenium/fluent/BaseFluentWebDriver.java
@@ -44,12 +44,12 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement span() {
         SingleResult single = single(tagName("span"), "span");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElement span(By by) {
         SingleResult single = single(by, "span");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements spans() {
@@ -80,12 +80,12 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement div() {
         SingleResult single = single(tagName("div"), "div");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElement div(By by) {
         SingleResult single = single(by, "div");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements divs() {
@@ -100,12 +100,12 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement button() {
         SingleResult single = single(tagName("button"), "button");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElement button(By by) {
         SingleResult single = single(by, "button");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements buttons() {
@@ -120,12 +120,12 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement link() {
         SingleResult single = single(tagName("a"), "a");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElement link(By by) {
         SingleResult single = single(by, "a");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements links() {
@@ -140,12 +140,12 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement input() {
         SingleResult single = single(tagName("input"), "input");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElement input(By by) {
         SingleResult single = single(by, "input");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements inputs() {
@@ -180,12 +180,12 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement h1() {
         SingleResult single = single(tagName("h1"), "h1");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElement h1(By by) {
         SingleResult single = single(by, "h1");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements h1s() {
@@ -200,12 +200,12 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement h2() {
         SingleResult single = single(tagName("h2"), "h2");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElement h2(By by) {
         SingleResult single = single(by, "h2");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements h2s() {
@@ -220,7 +220,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement h3() {
         SingleResult single = single(tagName("h3"), "h3");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements h3s() {
@@ -230,7 +230,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement h3(By by) {
         SingleResult single = single(by, "h3");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements h3s(By by) {
@@ -240,7 +240,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement h4(){
         SingleResult single = single(tagName("h4"), "h4");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements h4s() {
@@ -250,7 +250,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement h4(By by) {
         SingleResult single = single(by, "h4");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements h4s(By by) {
@@ -260,7 +260,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement p() {
         SingleResult single = single(tagName("p"), "p");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements ps() {
@@ -270,7 +270,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement p(By by) {
         SingleResult single = single(by, "p");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements ps(By by) {
@@ -280,7 +280,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement img() {
         SingleResult single = single(tagName("img"), "img");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements imgs() {
@@ -290,7 +290,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement img(By by) {
         SingleResult single = single(by, "img");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements imgs(By by) {
@@ -300,7 +300,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement table() {
         SingleResult single = single(tagName("table"), "table");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements tables() {
@@ -310,7 +310,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement table(By by) {
         SingleResult single = single(by, "table");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements tables(By by) {
@@ -320,7 +320,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement fieldset() {
         SingleResult single = single(tagName("fieldset"), "fieldset");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements fieldsets() {
@@ -330,7 +330,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement fieldset(By by) {
         SingleResult single = single(by, "fieldset");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements fieldsets(By by) {
@@ -340,7 +340,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement legend() {
         SingleResult single = single(tagName("legend"), "legend");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements legends() {
@@ -350,7 +350,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement legend(By by) {
         SingleResult single = single(by, "legend");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements legends(By by) {
@@ -360,7 +360,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement tr() {
         SingleResult single = single(tagName("tr"), "tr");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements trs() {
@@ -370,7 +370,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement tr(By by) {
         SingleResult single = single(by, "tr");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements trs(By by) {
@@ -380,7 +380,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement td() {
         SingleResult single = single(tagName("td"), "td");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements tds() {
@@ -390,7 +390,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement td(By by) {
         SingleResult single = single(by, "td");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements tds(By by) {
@@ -400,7 +400,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement th() {
         SingleResult single = single(tagName("th"), "th");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements ths() {
@@ -410,7 +410,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement th(By by) {
         SingleResult single = single(by, "th");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements ths(By by) {
@@ -420,7 +420,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement ul() {
         SingleResult single = single(tagName("ul"), "ul");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements uls() {
@@ -430,7 +430,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement ul(By by) {
         SingleResult single = single(by, "ul");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements uls(By by) {
@@ -440,7 +440,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement ol() {
         SingleResult single = single(tagName("ol"), "ol");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements ols() {
@@ -450,7 +450,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement ol(By by) {
         SingleResult single = single(by, "ol");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements ols(By by) {
@@ -460,7 +460,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement form() {
         SingleResult single = single(tagName("form"), "form");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements forms() {
@@ -470,7 +470,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement form(By by) {
         SingleResult single = single(by, "form");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements forms(By by) {
@@ -480,7 +480,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement textarea() {
         SingleResult single = single(tagName("textarea"), "textarea");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements textareas() {
@@ -490,7 +490,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement textarea(By by) {
         SingleResult single = single(by, "textarea");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements textareas(By by) {
@@ -500,7 +500,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement option() {
         SingleResult single = single(tagName("option"), "option");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements options() {
@@ -510,7 +510,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement option(By by) {
         SingleResult single = single(by, "option");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements options(By by) {
@@ -520,12 +520,12 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement li() {
         SingleResult single = single(tagName("li"), "li");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElement li(By by) {
         SingleResult single = single(by, "li");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements lis() {
@@ -540,7 +540,7 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement map() {
         SingleResult single = single(tagName("map"), "map");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements maps() {
@@ -550,12 +550,16 @@ public abstract class BaseFluentWebDriver implements FluentWebDriver {
 
     public FluentWebElement map(By by) {
         SingleResult single = single(by, "map");
-        return new FluentWebElement(delegate, single.getResult(), single.getCtx());
+        return newFluentWebElement(delegate, single.getResult(), single.getCtx());
     }
 
     public FluentWebElements maps(By by) {
         MultipleResult multiple = multiple(by, "map");
         return newFluentWebElements(multiple.getResult(), multiple.getCtx());
+    }
+
+    protected FluentWebElement newFluentWebElement(WebDriver delegate, WebElement result, Context context) {
+        return new FluentWebElement(delegate, result, context);
     }
 
     public TestableString url() {

--- a/src/main/java/org/seleniumhq/selenium/fluent/DisappearedFluentWebElement.java
+++ b/src/main/java/org/seleniumhq/selenium/fluent/DisappearedFluentWebElement.java
@@ -1,0 +1,535 @@
+package org.seleniumhq.selenium.fluent;
+import org.openqa.selenium.*;
+import java.util.List;
+public class DisappearedFluentWebElement extends FluentWebElement {
+    public DisappearedFluentWebElement(WebDriver delegate, Context context) {
+        super(delegate, null, context);
+    }
+    private UnsupportedOperationException meaningless(final String invocation) {
+        return new UnsupportedOperationException(invocation + " has no meaning for disappeared element");
+    }
+    @Override
+    protected WebElement findIt(By by) {
+        throw meaningless("findIt('" + by + "')");
+    }
+    @Override
+    protected List<WebElement> findThem(By by) {
+        throw meaningless("findThem('" + by + "')");
+    }
+    @Override
+    protected WebElement actualFindIt(By by) {
+        throw meaningless("actualFindIt('" + by + "')");
+    }
+    @Override
+    protected List<WebElement> actualFindThem(By by) {
+        throw meaningless("actualFindThem('" + by + "')");
+    }
+    @Override
+    public FluentWebElement click() {
+        throw meaningless("click()");
+    }
+    @Override
+    public FluentWebElement clearField() {
+        throw meaningless("clearField()");
+    }
+    @Override
+    public FluentWebElement submit() {
+        throw meaningless("submit()");
+    }
+    @Override
+    public FluentWebElement sendKeys(CharSequence... keysToSend) {
+        throw meaningless("sendkeys('" + keysToSend + "')");
+    }
+    @Override
+    public TestableString getTagName() {
+        throw meaningless("getTagName()");
+    }
+    @Override
+    public boolean isSelected() {
+        throw meaningless("isSelected()");
+    }
+    @Override
+    public boolean isEnabled() {
+        throw meaningless("isEnabled()");
+    }
+    @Override
+    public boolean isDisplayed() {
+        throw meaningless("isEnabled()");
+    }
+    @Override
+    public Point getLocation() {
+        throw meaningless("getLocation()");
+    }
+    @Override
+    public Dimension getSize() {
+        throw meaningless("getSize()");
+    }
+    @Override
+    public TestableString cssValue(String cssName) {
+        throw meaningless("cssValue('" + cssName + "')");
+    }
+    @Override
+    public TestableString attribute(String attr) {
+        throw meaningless("attribute('" + attr + "')");
+    }
+    @Override
+    public TestableString getText() {
+        throw meaningless("getSize()");
+    }
+    @Override
+    public WebElementValue<Point> location() {
+        throw meaningless("location()");
+    }
+    @Override
+    public WebElementValue<Dimension> size() {
+        throw meaningless("size()");
+    }
+    @Override
+    public WebElementValue<String> tagName() {
+        throw meaningless("tagName()");
+    }
+    @Override
+    public WebElementValue<Boolean> selected() {
+        throw meaningless("selected()");
+    }
+    @Override
+    public WebElementValue<Boolean> enabled() {
+        throw meaningless("enabled()");
+    }
+    @Override
+    public WebElementValue<Boolean> displayed() {
+        throw meaningless("displayed()");
+    }
+    @Override
+    public WebElementValue<String> text() {
+        throw meaningless("text()");
+    }
+    @Override
+    public FluentWebElement within(Period period) {
+        throw meaningless("within('" + period.toString() + "')");
+    }
+    @Override
+    public FluentWebDriver without(Period period) {
+        throw meaningless("without('" + period.toString() + "')");
+    }
+    @Override
+    protected FluentWebElements makeFluentWebElements(List<FluentWebElement> results, Context context) {
+        throw meaningless("makeFluentWebElements('" + results.toString() + ", " + context.toString() + "')");
+    }
+    @Override
+    protected String charSeqArrayAsHumanString(CharSequence[] keysToSend) {
+        throw meaningless("charSeqArrayAsHumanString('" + keysToSend + "')");
+    }
+    @Override
+    public FluentWebElement span() {
+        throw meaningless("span()");
+    }
+    @Override
+    public FluentWebElement span(By by) {
+        throw meaningless("span('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements spans() {
+        throw meaningless("spans()");
+    }
+    @Override
+    public FluentWebElements spans(By by) {
+        throw meaningless("spans('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement div() {
+        throw meaningless("div()");
+    }
+    @Override
+    public FluentWebElement div(By by) {
+        throw meaningless("div('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements divs() {
+        throw meaningless("divs()");
+    }
+    @Override
+    public FluentWebElements divs(By by) {
+        throw meaningless("divs('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement button() {
+        throw meaningless("button()");
+    }
+    @Override
+    public FluentWebElement button(By by) {
+        throw meaningless("button('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements buttons() {
+        throw meaningless("buttons()");
+    }
+    @Override
+    public FluentWebElements buttons(By by) {
+        throw meaningless("buttons('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement link() {
+        throw meaningless("link()");
+    }
+    @Override
+    public FluentWebElement link(By by) {
+        throw meaningless("link('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements links() {
+        throw meaningless("links()");
+    }
+    @Override
+    public FluentWebElements links(By by) {
+        throw meaningless("links('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement input() {
+        throw meaningless("input()");
+    }
+    @Override
+    public FluentWebElement input(By by) {
+        throw meaningless("input('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements inputs() {
+        throw meaningless("inputs()");
+    }
+    @Override
+    public FluentWebElements inputs(By by) {
+        throw meaningless("input('" + by.toString() + "')");
+    }
+    @Override
+    public FluentSelect select() {
+        throw meaningless("select()");
+    }
+    @Override
+    public FluentSelect select(By by) {
+        throw meaningless("select('" + by.toString() + "')");
+    }
+    @Override
+    public FluentSelects selects() {
+        throw meaningless("selects()");
+    }
+    @Override
+    public FluentSelects selects(By by) {
+        throw meaningless("selects('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement h1() {
+        return super.h1();
+    }
+    @Override
+    public FluentWebElement h1(By by) {
+        throw meaningless("h1('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements h1s() {
+        throw meaningless("h1s()");
+    }
+    @Override
+    public FluentWebElements h1s(By by) {
+        throw meaningless("h1s('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement h2() {
+        throw meaningless("h2()");
+    }
+    @Override
+    public FluentWebElement h2(By by) {
+        throw meaningless("h2('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements h2s() {
+        throw meaningless("h2s()");
+    }
+    @Override
+    public FluentWebElements h2s(By by) {
+        throw meaningless("h2s('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement h3() {
+        throw meaningless("h3()");
+    }
+    @Override
+    public FluentWebElements h3s() {
+        throw meaningless("h3s()");
+    }
+    @Override
+    public FluentWebElement h3(By by) {
+        throw meaningless("h3('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements h3s(By by) {
+        throw meaningless("h3s('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement h4() {
+        throw meaningless("h4()");
+    }
+    @Override
+    public FluentWebElements h4s() {
+        throw meaningless("h4s()");
+    }
+    @Override
+    public FluentWebElement h4(By by) {
+        throw meaningless("h4('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements h4s(By by) {
+        throw meaningless("h4s('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement p() {
+        throw meaningless("p()");
+    }
+    @Override
+    public FluentWebElements ps() {
+        throw meaningless("ps()");
+    }
+    @Override
+    public FluentWebElement p(By by) {
+        throw meaningless("p('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements ps(By by) {
+        throw meaningless("ps('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement img() {
+        throw meaningless("img()");
+    }
+    @Override
+    public FluentWebElements imgs() {
+        throw meaningless("imgs()");
+    }
+    @Override
+    public FluentWebElement img(By by) {
+        throw meaningless("img('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements imgs(By by) {
+        throw meaningless("imgs('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement table() {
+        throw meaningless("table()");
+    }
+    @Override
+    public FluentWebElements tables() {
+        throw meaningless("tables()");
+    }
+    @Override
+    public FluentWebElement table(By by) {
+        throw meaningless("table('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements tables(By by) {
+        throw meaningless("tables('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement fieldset() {
+        throw meaningless("fieldset()");
+    }
+    @Override
+    public FluentWebElements fieldsets() {
+        throw meaningless("fieldsets()");
+    }
+    @Override
+    public FluentWebElement fieldset(By by) {
+        throw meaningless("fieldset('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements fieldsets(By by) {
+        throw meaningless("fieldsets('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement legend() {
+        throw meaningless("legend()");
+    }
+    @Override
+    public FluentWebElements legends() {
+        throw meaningless("legends()");
+    }
+    @Override
+    public FluentWebElement legend(By by) {
+        throw meaningless("legend('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements legends(By by) {
+        throw meaningless("legends('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement tr() {
+        throw meaningless("tr()");
+    }
+    @Override
+    public FluentWebElements trs() {
+        throw meaningless("trs()");
+    }
+    @Override
+    public FluentWebElement tr(By by) {
+        throw meaningless("tr('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements trs(By by) {
+        throw meaningless("trs('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement td() {
+        throw meaningless("td()");
+    }
+    @Override
+    public FluentWebElements tds() {
+        throw meaningless("tds()");
+    }
+    @Override
+    public FluentWebElement td(By by) {
+        throw meaningless("td('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements tds(By by) {
+        throw meaningless("tds('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement th() {
+        throw meaningless("th()");
+    }
+    @Override
+    public FluentWebElements ths() {
+        throw meaningless("ths()");
+    }
+    @Override
+    public FluentWebElement th(By by) {
+        throw meaningless("th('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements ths(By by) {
+        throw meaningless("ths('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement ul() {
+        throw meaningless("ul()");
+    }
+    @Override
+    public FluentWebElements uls() {
+        throw meaningless("uls()");
+    }
+    @Override
+    public FluentWebElement ul(By by) {
+        throw meaningless("ul('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements uls(By by) {
+        throw meaningless("uls('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement ol() {
+        throw meaningless("ol()");
+    }
+    @Override
+    public FluentWebElements ols() {
+        throw meaningless("ols()");
+    }
+    @Override
+    public FluentWebElement ol(By by) {
+        throw meaningless("ol('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements ols(By by) {
+        throw meaningless("ols('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement form() {
+        throw meaningless("form()");
+    }
+    @Override
+    public FluentWebElements forms() {
+        throw meaningless("forms()");
+    }
+    @Override
+    public FluentWebElement form(By by) {
+        throw meaningless("form('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements forms(By by) {
+        throw meaningless("forms('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement textarea() {
+        throw meaningless("textarea()");
+    }
+    @Override
+    public FluentWebElements textareas() {
+        throw meaningless("textareas()");
+    }
+    @Override
+    public FluentWebElement textarea(By by) {
+        throw meaningless("textarea('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements textareas(By by) {
+        throw meaningless("textareas('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement option() {
+        throw meaningless("option()");
+    }
+    @Override
+    public FluentWebElements options() {
+        throw meaningless("options()");
+    }
+    @Override
+    public FluentWebElement option(By by) {
+        throw meaningless("option('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements options(By by) {
+        throw meaningless("options('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement li() {
+        throw meaningless("li()");
+    }
+    @Override
+    public FluentWebElement li(By by) {
+        throw meaningless("li('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements lis() {
+        throw meaningless("lis()");
+    }
+    @Override
+    public FluentWebElements lis(By by) {
+        throw meaningless("lis('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElement map() {
+        throw meaningless("map()");
+    }
+    @Override
+    public FluentWebElements maps() {
+        throw meaningless("maps()");
+    }
+    @Override
+    public FluentWebElement map(By by) {
+        throw meaningless("map('" + by.toString() + "')");
+    }
+    @Override
+    public FluentWebElements maps(By by) {
+        throw meaningless("maps('" + by.toString() + "')");
+    }
+    @Override
+    public TestableString url() {
+        throw meaningless("url()");
+    }
+    @Override
+    protected Period getPeriod() {
+        throw meaningless("getPeriod()");
+    }
+    @Override
+    public TestableString title() {
+        throw meaningless("title()");
+    }
+}

--- a/src/test/java/org/seleniumhq/selenium/fluent/WithoutTest.java
+++ b/src/test/java/org/seleniumhq/selenium/fluent/WithoutTest.java
@@ -64,6 +64,18 @@ public class WithoutTest {
         }
     }
 
+    @Test
+    public void meaninglessChainedDivDetected() {
+        when(webDriver.findElement(By.tagName("div"))).thenThrow(new ElementNotFoundException("div", null, null));
+
+        try {
+            final FluentWebElement disappearedElement = fluentWebDriver.without(secs(100)).div();
+            disappearedElement.div();
+            fail();
+        } catch(UnsupportedOperationException ex) {
+        }
+    }
+
 
     @Test
     public void spanIsGoneBeforeWeLookForIt() {


### PR DESCRIPTION
Using without(time).element(by) will now succeed if element 'by' is disappeared within duration specified by 'time'.  however, chaining in the form of without(time).element(by).element(by) would throw null pointer exceptions.

This change makes all chained ops off of the disappeared element throw an UnsupportedOperationException.
