### PR TITLE
Add generic tag support to not be limited by standard HTML tag

### DIFF
--- a/java/src/main/java/org/seleniumhq/selenium/fluent/FluentWebDriver.java
+++ b/java/src/main/java/org/seleniumhq/selenium/fluent/FluentWebDriver.java
@@ -87,6 +87,26 @@ public class FluentWebDriver extends Internal.BaseFluentWebDriver {
     }
 
     @Override
+    public FluentWebElement element() {
+        return (FluentWebElement) super.element();
+    }
+
+    @Override
+    public FluentWebElement element(By by) {
+        return (FluentWebElement) super.element(by);
+    }
+
+    @Override
+    public FluentWebElements elements() {
+        return (FluentWebElements) super.elements();
+    }
+
+    @Override
+    public FluentWebElements elements(By by) {
+        return (FluentWebElements) super.elements(by);
+    }
+
+    @Override
     public FluentWebElement span() {
         return (FluentWebElement) super.span();
     }
@@ -896,6 +916,14 @@ public class FluentWebDriver extends Internal.BaseFluentWebDriver {
         public BooleanResultsAdapter invert(boolean b) {
             this.invert = b;
             return this;
+        }
+
+        public boolean element() {
+            return returnBool(bfwd.element());
+        }
+
+        public boolean element(By by) {
+            return returnBool(bfwd.element(by));
         }
 
         public boolean span() {

--- a/java/src/main/java/org/seleniumhq/selenium/fluent/FluentWebElement.java
+++ b/java/src/main/java/org/seleniumhq/selenium/fluent/FluentWebElement.java
@@ -165,6 +165,26 @@ public class FluentWebElement extends Internal.BaseFluentWebElement {
     }
 
     @Override
+    public FluentWebElement element() {
+        return (FluentWebElement) super.element();
+    }
+
+    @Override
+    public FluentWebElement element(By by) {
+        return (FluentWebElement) super.element(by);
+    }
+
+    @Override
+    public FluentWebElements elements() {
+        return (FluentWebElements) super.elements();
+    }
+
+    @Override
+    public FluentWebElements elements(By by) {
+        return (FluentWebElements) super.elements(by);
+    }
+
+    @Override
     public FluentWebElement span() {
         return (FluentWebElement) super.span();
     }
@@ -982,6 +1002,22 @@ public class FluentWebElement extends Internal.BaseFluentWebElement {
 
         protected Boolean durationHasElapsed(Long startMillis) {
             return duration.getEndMillis(startMillis) <= System.currentTimeMillis();
+        }
+
+        public void element() {
+            delegate.element();
+        }
+
+        public void element(By by) {
+            delegate.element(by);
+        }
+
+        public void elements() {
+            delegate.elements();
+        }
+
+        public void elements(By by) {
+            delegate.elements(by);
         }
 
         public void span() {

--- a/java/src/main/java/org/seleniumhq/selenium/fluent/Internal.java
+++ b/java/src/main/java/org/seleniumhq/selenium/fluent/Internal.java
@@ -44,6 +44,8 @@ public class Internal {
 
     public abstract static class BaseFluentWebDriver {
 
+        protected static final String GENERIC_TAG = "*";
+
         protected final WebDriver delegate;
         protected final Context context;
         protected final Monitor monitor;
@@ -66,20 +68,6 @@ public class Internal {
             return delegate;
         }
 
-        protected BaseFluentWebElement span() {
-            SingleResult single = single(tagName("span"), "span");
-            return newFluentWebElement(delegate, single.getResult(), single.getCtx());
-        }
-
-        protected BaseFluentWebElement span(By by) {
-            SingleResult single = single(by, "span");
-            return newFluentWebElement(delegate, single.getResult(), single.getCtx());
-        }
-
-        protected BaseFluentWebElements spans() {
-            return newFluentWebElements(multiple(tagName("span"), "span"));
-        }
-
         protected BaseFluentWebElements newFluentWebElements(MultipleResult multiple) {
             List<WebElement> result = multiple.getResult();
             Context ctx = multiple.getCtx();
@@ -96,6 +84,38 @@ public class Internal {
                 elems.add(new FluentSelect(delegate, aResult, ctx, monitor, booleanInsteadOfNotFoundException));
             }
             return new FluentSelects(delegate, elems, ctx, monitor, booleanInsteadOfNotFoundException);
+        }
+
+        protected BaseFluentWebElement element() {
+            SingleResult single = single(tagName(GENERIC_TAG), GENERIC_TAG);
+            return newFluentWebElement(delegate, single.getResult(), single.getCtx());
+        }
+
+        protected BaseFluentWebElement element(By by) {
+            SingleResult single = single(by, GENERIC_TAG);
+            return newFluentWebElement(delegate, single.getResult(), single.getCtx());
+        }
+
+        protected BaseFluentWebElements elements() {
+            return newFluentWebElements(multiple(tagName(GENERIC_TAG), GENERIC_TAG));
+        }
+
+        protected BaseFluentWebElements elements(By by) {
+            return newFluentWebElements(multiple(by, GENERIC_TAG));
+        }
+
+        protected BaseFluentWebElement span() {
+            SingleResult single = single(tagName("span"), "span");
+            return newFluentWebElement(delegate, single.getResult(), single.getCtx());
+        }
+
+        protected BaseFluentWebElement span(By by) {
+            SingleResult single = single(by, "span");
+            return newFluentWebElement(delegate, single.getResult(), single.getCtx());
+        }
+
+        protected BaseFluentWebElements spans() {
+            return newFluentWebElements(multiple(tagName("span"), "span"));
         }
 
         protected BaseFluentWebElements spans(By by) {
@@ -826,7 +846,7 @@ public class Internal {
 
         private SingleResult single(final By by, final String tagName) {
             final By by2 = fixupBy(by, tagName);
-            Context ctx = contextualize(by, tagName);
+            Context ctx = contextualize(by2, tagName);
             final WebElementHolder result;
             try {
                 changeTimeout();
@@ -862,7 +882,6 @@ public class Internal {
             private final Context ctx;
             private final SearchContext searchContext;
 
-
             public FindElement(By by2, String tagName, Context ctx, SearchContext searchContext) {
                 this.by2 = by2;
                 this.tagName = tagName;
@@ -880,7 +899,9 @@ public class Internal {
                     }
                 } else {
                     WebElement it = findElement(by2, ctx, searchContext);
-                    assertTagIs(it.getTagName(), tagName);
+                    if (!GENERIC_TAG.equals(tagName)) {
+                        assertTagIs(it.getTagName(), tagName);
+                    }
                     return it;
                 }
             }
@@ -937,8 +958,10 @@ public class Internal {
 
             public List<WebElement> execute() {
                 List<WebElement> results = findElements(by2, ctx);
-                for (WebElement webElement : results) {
-                    assertTagIs(webElement.getTagName(), tagName);
+                if (!GENERIC_TAG.equals(tagName)) {
+                    for (WebElement webElement : results) {
+                        assertTagIs(webElement.getTagName(), tagName);
+                    }
                 }
                 return results;
             }

--- a/java/src/main/java/org/seleniumhq/selenium/fluent/internal/NegatingFluentWebDriver.java
+++ b/java/src/main/java/org/seleniumhq/selenium/fluent/internal/NegatingFluentWebDriver.java
@@ -25,6 +25,14 @@ public class NegatingFluentWebDriver {
 
     // We are deliberately returning void here, to halt fluency.
 
+    public void element() {
+        delegate.element();
+    }
+
+    public void element(By by) {
+        delegate.element(by);
+    }
+
     public void span() {
         delegate.span();
     }

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/BaseTest.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/BaseTest.java
@@ -32,7 +32,8 @@ public class BaseTest {
         fwd = new FluentWebDriver(wd);
     }
 
-    protected void setupExpecations(String name) {
+    protected void setupExpectationsSingle(String name) {
+        when(wd.findElement(By.cssSelector("*"))).thenReturn(we);
         when(wd.findElement(By.tagName(name))).thenReturn(we);
         when(we.getTagName()).thenReturn(name);
         when(we.findElement(By.xpath(".//"+name+"[@foo = 'bar']"))).thenReturn(we2);
@@ -44,7 +45,11 @@ public class BaseTest {
         when(we5.getTagName()).thenReturn(name);
     }
 
-    protected void verifications(String name) {
+    protected void setupExpectationsSingleGeneric() {
+        setupExpectationsSingle("*");
+    }
+
+    protected void verificationsSingle(String name) {
         verify(wd).findElement(By.tagName(name));
         verify(we).getTagName();
         verify(we).findElement(By.xpath(".//"+name+"[@foo = 'bar']"));
@@ -57,7 +62,16 @@ public class BaseTest {
         verifyNoMoreInteractions(wd, we, we2, we3, we4, we5);
     }
 
-    protected void setupExpecations2(String button) {
+    protected void verificationsSingleGeneric() {
+        String name = "*";
+        verify(wd).findElement(By.tagName(name));
+        verify(we).findElement(By.xpath(".//"+name+"[@foo = 'bar']"));
+        verify(we2).findElement(By.cssSelector("baz"));
+        verify(we3).findElements(By.tagName(name));
+        verifyNoMoreInteractions(wd, we, we2, we3, we4, we5);
+    }
+
+    protected void setupExpectationsMultiple(String button) {
         when(wd.findElement(By.tagName(button))).thenReturn(we);
         when(we.getTagName()).thenReturn(button);
         when(we.findElements(By.name("qux"))).thenReturn(newArrayList(we2, we3));
@@ -65,7 +79,11 @@ public class BaseTest {
         when(we3.getTagName()).thenReturn(button);
     }
 
-    protected void verifications2(String name) {
+    protected void setupExpectationsMultipleGeneric() {
+        setupExpectationsMultiple("*");
+    }
+
+    protected void verificationsMultiple(String name) {
         verify(wd).findElement(By.tagName(name));
         verify(we).getTagName();
         verify(we).findElements(By.name("qux"));
@@ -73,4 +91,12 @@ public class BaseTest {
         verify(we3).getTagName();
         verifyNoMoreInteractions(wd, we, we2, we3);
     }
+
+    protected void verificationsMultipleGeneric() {
+        String name = "*";
+        verify(wd).findElement(By.tagName(name));
+        verify(we).findElements(By.name("qux"));
+        verifyNoMoreInteractions(wd, we, we2, we3);
+    }
+
 }

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/BooleanInsteadOfNoSuchElementExceptionTest.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/BooleanInsteadOfNoSuchElementExceptionTest.java
@@ -133,7 +133,8 @@ public class BooleanInsteadOfNoSuchElementExceptionTest {
             String name = method.getName();
             if (method.getReturnType().equals(Boolean.TYPE) && !name.equals("returnBool")) {
                 if (method.getParameterTypes().length == 0) {
-                    when(wd.findElement(tagName(name.replace("link","a")))).thenThrow(new NoSuchElementException("boo"));
+                    String tagName = name.replace("link", "a").replace("element", "*");
+                    when(wd.findElement(tagName(tagName))).thenThrow(new NoSuchElementException("boo"));
                     assertFalse((Boolean) method.invoke(bwa));
                 } else {
                     assertFalse((Boolean) method.invoke(bwa, byID));
@@ -141,7 +142,7 @@ public class BooleanInsteadOfNoSuchElementExceptionTest {
                 count++;
             }
         }
-        assertThat(count, equalTo(78));
+        assertThat(count, equalTo(80));
     }
 
 }

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/abbr.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/abbr.java
@@ -17,7 +17,7 @@ public class abbr extends BaseTest {
     @Test
     public void abbr_functionality() {
 
-        setupExpecations("abbr");
+        setupExpectationsSingle("abbr");
 
         FluentWebElements fe = fwd.abbr()
                 .abbr(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class abbr extends BaseTest {
                 .abbrs();
 
         assertThat(fe, notNullValue());
-        verifications("abbr");
+        verificationsSingle("abbr");
     }
 
     @Test
     public void abbrs_functionality() {
 
-        setupExpecations2("abbr");
+        setupExpectationsMultiple("abbr");
 
         FluentWebElements fe = fwd.abbr()
                 .abbrs(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("abbr");
+        verificationsMultiple("abbr");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/acronym.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/acronym.java
@@ -17,7 +17,7 @@ public class acronym extends BaseTest {
     @Test
     public void acronym_functionality() {
 
-        setupExpecations("acronym");
+        setupExpectationsSingle("acronym");
 
         FluentWebElements fe = fwd.acronym()
                 .acronym(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class acronym extends BaseTest {
                 .acronyms();
 
         assertThat(fe, notNullValue());
-        verifications("acronym");
+        verificationsSingle("acronym");
     }
 
     @Test
     public void acronyms_functionality() {
 
-        setupExpecations2("acronym");
+        setupExpectationsMultiple("acronym");
 
         FluentWebElements fe = fwd.acronym()
                 .acronyms(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("acronym");
+        verificationsMultiple("acronym");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/address.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/address.java
@@ -17,7 +17,7 @@ public class address extends BaseTest {
     @Test
     public void address_functionality() {
 
-        setupExpecations("address");
+        setupExpectationsSingle("address");
 
         FluentWebElements fe = fwd.address()
                 .address(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class address extends BaseTest {
                 .addresses();
 
         assertThat(fe, notNullValue());
-        verifications("address");
+        verificationsSingle("address");
     }
 
     @Test
     public void adresss_functionality() {
 
-        setupExpecations2("address");
+        setupExpectationsMultiple("address");
 
         FluentWebElements fe = fwd.address()
                 .addresses(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("address");
+        verificationsMultiple("address");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/area.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/area.java
@@ -17,7 +17,7 @@ public class area extends BaseTest {
     @Test
     public void area_functionality() {
 
-        setupExpecations("area");
+        setupExpectationsSingle("area");
 
         FluentWebElements fe = fwd.area()
                 .area(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class area extends BaseTest {
                 .areas();
 
         assertThat(fe, notNullValue());
-        verifications("area");
+        verificationsSingle("area");
     }
 
     @Test
     public void adresss_functionality() {
 
-        setupExpecations2("area");
+        setupExpectationsMultiple("area");
 
         FluentWebElements fe = fwd.area()
                 .areas(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("area");
+        verificationsMultiple("area");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/b.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/b.java
@@ -17,7 +17,7 @@ public class b extends BaseTest {
     @Test
     public void b_functionality() {
 
-        setupExpecations("b");
+        setupExpectationsSingle("b");
 
         FluentWebElements fe = fwd.b()
                 .b(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class b extends BaseTest {
                 .bs();
 
         assertThat(fe, notNullValue());
-        verifications("b");
+        verificationsSingle("b");
     }
 
     @Test
     public void bs_functionality() {
 
-        setupExpecations2("b");
+        setupExpectationsMultiple("b");
 
         FluentWebElements fe = fwd.b()
                 .bs(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("b");
+        verificationsMultiple("b");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/blockquote.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/blockquote.java
@@ -17,7 +17,7 @@ public class blockquote extends BaseTest {
     @Test
     public void blockquote_functionality() {
 
-        setupExpecations("blockquote");
+        setupExpectationsSingle("blockquote");
 
         FluentWebElements fe = fwd.blockquote()
                 .blockquote(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class blockquote extends BaseTest {
                 .blockquotes();
 
         assertThat(fe, notNullValue());
-        verifications("blockquote");
+        verificationsSingle("blockquote");
     }
 
     @Test
     public void blockquotes_functionality() {
 
-        setupExpecations2("blockquote");
+        setupExpectationsMultiple("blockquote");
 
         FluentWebElements fe = fwd.blockquote()
                 .blockquotes(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("blockquote");
+        verificationsMultiple("blockquote");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/button.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/button.java
@@ -19,7 +19,7 @@ public class button extends BaseTest {
     @Test
     public void button_functionality() {
 
-        setupExpecations("button");
+        setupExpectationsSingle("button");
 
         FluentWebElements fe = fwd.button()
                 .button(By.xpath("@foo = 'bar'"))
@@ -27,7 +27,7 @@ public class button extends BaseTest {
                 .buttons(); // very artificial, sure.
 
         assertThat(fe, notNullValue());
-        verifications("button");
+        verificationsSingle("button");
 
 
     }
@@ -35,13 +35,13 @@ public class button extends BaseTest {
     @Test
     public void buttons_functionality() {
 
-        setupExpecations2("button");
+        setupExpectationsMultiple("button");
 
         FluentWebElements fe = fwd.button().buttons(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("button");
+        verificationsMultiple("button");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/div.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/div.java
@@ -17,7 +17,7 @@ public class div extends BaseTest {
     @Test
     public void div_functionality() {
 
-        setupExpecations("div");
+        setupExpectationsSingle("div");
 
         FluentWebElements fe = fwd.div()
                 .div(By.xpath("@foo = 'bar'"))
@@ -25,19 +25,19 @@ public class div extends BaseTest {
                 .divs();
 
         assertThat(fe, notNullValue());
-        verifications("div");
+        verificationsSingle("div");
     }
 
     @Test
     public void divs_functionality() {
 
-        setupExpecations2("div");
+        setupExpectationsMultiple("div");
 
         FluentWebElements fe = fwd.div().divs(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("div");
+        verificationsMultiple("div");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/elem.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/elem.java
@@ -13,9 +13,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
-/**
- * @author t5e
- */
 public class elem extends BaseTest {
 
     @Test

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/elem.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/elem.java
@@ -1,0 +1,54 @@
+package org.seleniumhq.selenium.fluent.elements;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.seleniumhq.selenium.fluent.BaseTest;
+import org.seleniumhq.selenium.fluent.FluentExecutionStopped;
+import org.seleniumhq.selenium.fluent.FluentWebElements;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author t5e
+ */
+public class elem extends BaseTest {
+
+    @Test
+    public void element_functionality() {
+
+        setupExpectationsSingleGeneric();
+
+        FluentWebElements fe = fwd.element()
+            .element(By.xpath("@foo = 'bar'"))
+            .element(By.cssSelector("baz"))
+            .elements();
+
+        assertThat(fe, notNullValue());
+        verificationsSingleGeneric();
+    }
+
+    @Test
+    public void elements_functionality() {
+
+        setupExpectationsMultipleGeneric();
+
+        FluentWebElements fe = fwd.element().elements(By.name("qux"));
+
+        assertThat(fe, notNullValue());
+
+        verificationsMultipleGeneric();
+
+    }
+
+    @Test
+    @Ignore
+    public void element_mismatched() {
+        // We cannot test if element is mismatched, because element is not a type, It will by default return something
+        // different
+    }
+}

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/fieldset.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/fieldset.java
@@ -17,7 +17,7 @@ public class fieldset extends BaseTest {
     @Test
     public void fieldset_functionality() {
 
-        setupExpecations("fieldset");
+        setupExpectationsSingle("fieldset");
 
         FluentWebElements fe = fwd.fieldset()
                 .fieldset(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class fieldset extends BaseTest {
                 .fieldsets();
 
         assertThat(fe, notNullValue());
-        verifications("fieldset");
+        verificationsSingle("fieldset");
     }
 
     @Test
     public void fieldsets_functionality() {
 
-        setupExpecations2("fieldset");
+        setupExpectationsMultiple("fieldset");
 
         FluentWebElements fe = fwd.fieldset()
                 .fieldsets(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("fieldset");
+        verificationsMultiple("fieldset");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/figure.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/figure.java
@@ -17,7 +17,7 @@ public class figure extends BaseTest {
     @Test
     public void figure_functionality() {
 
-        setupExpecations("figure");
+        setupExpectationsSingle("figure");
 
         FluentWebElements fe = fwd.figure()
                 .figure(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class figure extends BaseTest {
                 .figures();
 
         assertThat(fe, notNullValue());
-        verifications("figure");
+        verificationsSingle("figure");
     }
 
     @Test
     public void figures_functionality() {
 
-        setupExpecations2("figure");
+        setupExpectationsMultiple("figure");
 
         FluentWebElements fe = fwd.figure()
                 .figures(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("figure");
+        verificationsMultiple("figure");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/footer.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/footer.java
@@ -17,7 +17,7 @@ public class footer extends BaseTest {
     @Test
     public void footer_functionality() {
 
-        setupExpecations("footer");
+        setupExpectationsSingle("footer");
 
         FluentWebElements fe = fwd.footer()
                 .footer(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class footer extends BaseTest {
                 .footers();
 
         assertThat(fe, notNullValue());
-        verifications("footer");
+        verificationsSingle("footer");
     }
 
     @Test
     public void footers_functionality() {
 
-        setupExpecations2("footer");
+        setupExpectationsMultiple("footer");
 
         FluentWebElements fe = fwd.footer()
                 .footers(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("footer");
+        verificationsMultiple("footer");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/form.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/form.java
@@ -17,7 +17,7 @@ public class form extends BaseTest {
     @Test
     public void form_functionality() {
 
-        setupExpecations("form");
+        setupExpectationsSingle("form");
 
         FluentWebElements fe = fwd.form()
                 .form(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class form extends BaseTest {
                 .forms();
 
         assertThat(fe, notNullValue());
-        verifications("form");
+        verificationsSingle("form");
     }
 
     @Test
     public void forms_functionality() {
 
-        setupExpecations2("form");
+        setupExpectationsMultiple("form");
 
         FluentWebElements fe = fwd.form()
                 .forms(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("form");
+        verificationsMultiple("form");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/h1.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/h1.java
@@ -17,7 +17,7 @@ public class h1 extends BaseTest {
     @Test
     public void h1_functionality() {
 
-        setupExpecations("h1");
+        setupExpectationsSingle("h1");
 
         FluentWebElements fe = fwd.h1()
                 .h1(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class h1 extends BaseTest {
                 .h1s();
 
         assertThat(fe, notNullValue());
-        verifications("h1");
+        verificationsSingle("h1");
     }
 
     @Test
     public void h1s_functionality() {
 
-        setupExpecations2("h1");
+        setupExpectationsMultiple("h1");
 
         FluentWebElements fe = fwd.h1()
                 .h1s(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("h1");
+        verificationsMultiple("h1");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/h2.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/h2.java
@@ -17,7 +17,7 @@ public class h2 extends BaseTest {
     @Test
     public void h2_functionality() {
 
-        setupExpecations("h2");
+        setupExpectationsSingle("h2");
 
         Internal.BaseFluentWebElements fe = fwd.h2()
                 .h2(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class h2 extends BaseTest {
                 .h2s();
 
         assertThat(fe, notNullValue());
-        verifications("h2");
+        verificationsSingle("h2");
     }
 
     @Test
     public void h2s_functionality() {
 
-        setupExpecations2("h2");
+        setupExpectationsMultiple("h2");
 
         Internal.BaseFluentWebElements fe = fwd.h2()
                 .h2s(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("h2");
+        verificationsMultiple("h2");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/h3.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/h3.java
@@ -17,7 +17,7 @@ public class h3 extends BaseTest {
     @Test
     public void h3_functionality() {
 
-        setupExpecations("h3");
+        setupExpectationsSingle("h3");
 
         FluentWebElements fe = fwd.h3()
                 .h3(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class h3 extends BaseTest {
                 .h3s();
 
         assertThat(fe, notNullValue());
-        verifications("h3");
+        verificationsSingle("h3");
     }
 
     @Test
     public void h3s_functionality() {
 
-        setupExpecations2("h3");
+        setupExpectationsMultiple("h3");
 
         FluentWebElements fe = fwd.h3()
                 .h3s(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("h3");
+        verificationsMultiple("h3");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/h4.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/h4.java
@@ -17,7 +17,7 @@ public class h4 extends BaseTest {
     @Test
     public void h4_functionality() {
 
-        setupExpecations("h4");
+        setupExpectationsSingle("h4");
 
         FluentWebElements fe = fwd.h4()
                 .h4(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class h4 extends BaseTest {
                 .h4s();
 
         assertThat(fe, notNullValue());
-        verifications("h4");
+        verificationsSingle("h4");
     }
 
     @Test
     public void h4s_functionality() {
 
-        setupExpecations2("h4");
+        setupExpectationsMultiple("h4");
 
         FluentWebElements fe = fwd.h4()
                 .h4s(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("h4");
+        verificationsMultiple("h4");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/header.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/header.java
@@ -17,7 +17,7 @@ public class header extends BaseTest {
     @Test
     public void header_functionality() {
 
-        setupExpecations("header");
+        setupExpectationsSingle("header");
 
         FluentWebElements fe = fwd.header()
                 .header(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class header extends BaseTest {
                 .headers();
 
         assertThat(fe, notNullValue());
-        verifications("header");
+        verificationsSingle("header");
     }
 
     @Test
     public void headers_functionality() {
 
-        setupExpecations2("header");
+        setupExpectationsMultiple("header");
 
         FluentWebElements fe = fwd.header()
                 .headers(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("header");
+        verificationsMultiple("header");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/img.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/img.java
@@ -17,7 +17,7 @@ public class img extends BaseTest {
     @Test
     public void img_functionality() {
 
-        setupExpecations("img");
+        setupExpectationsSingle("img");
 
         FluentWebElements fe = fwd.img()
                 .img(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class img extends BaseTest {
                 .imgs();
 
         assertThat(fe, notNullValue());
-        verifications("img");
+        verificationsSingle("img");
     }
 
     @Test
     public void imgs_functionality() {
 
-        setupExpecations2("img");
+        setupExpectationsMultiple("img");
 
         FluentWebElements fe = fwd.img()
                 .imgs(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("img");
+        verificationsMultiple("img");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/input.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/input.java
@@ -17,7 +17,7 @@ public class input extends BaseTest {
     @Test
     public void input_functionality() {
 
-        setupExpecations("input");
+        setupExpectationsSingle("input");
 
         FluentWebElements fe = fwd.input()
                 .input(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class input extends BaseTest {
                 .inputs();
 
         assertThat(fe, notNullValue());
-        verifications("input");
+        verificationsSingle("input");
     }
 
     @Test
     public void inputs_functionality() {
 
-        setupExpecations2("input");
+        setupExpectationsMultiple("input");
 
         FluentWebElements fe = fwd.input()
                 .inputs(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("input");
+        verificationsMultiple("input");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/label.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/label.java
@@ -17,7 +17,7 @@ public class label extends BaseTest {
     @Test
     public void label_functionality() {
 
-        setupExpecations("label");
+        setupExpectationsSingle("label");
 
         FluentWebElements fe = fwd.label()
                 .label(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class label extends BaseTest {
                 .labels();
 
         assertThat(fe, notNullValue());
-        verifications("label");
+        verificationsSingle("label");
     }
 
     @Test
     public void labels_functionality() {
 
-        setupExpecations2("label");
+        setupExpectationsMultiple("label");
 
         FluentWebElements fe = fwd.label()
                 .labels(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("label");
+        verificationsMultiple("label");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/legend.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/legend.java
@@ -17,7 +17,7 @@ public class legend extends BaseTest {
     @Test
     public void legend_functionality() {
 
-        setupExpecations("legend");
+        setupExpectationsSingle("legend");
 
         Internal.BaseFluentWebElements fe = fwd.legend()
                 .legend(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class legend extends BaseTest {
                 .legends();
 
         assertThat(fe, notNullValue());
-        verifications("legend");
+        verificationsSingle("legend");
     }
 
     @Test
     public void legends_functionality() {
 
-        setupExpecations2("legend");
+        setupExpectationsMultiple("legend");
 
         Internal.BaseFluentWebElements fe = fwd.legend()
                 .legends(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("legend");
+        verificationsMultiple("legend");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/li.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/li.java
@@ -17,7 +17,7 @@ public class li extends BaseTest {
     @Test
     public void li_functionality() {
 
-        setupExpecations("li");
+        setupExpectationsSingle("li");
 
         FluentWebElements fe = fwd.li()
                 .li(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class li extends BaseTest {
                 .lis();
 
         assertThat(fe, notNullValue());
-        verifications("li");
+        verificationsSingle("li");
     }
 
     @Test
     public void lis_functionality() {
 
-        setupExpecations2("li");
+        setupExpectationsMultiple("li");
 
         FluentWebElements fe = fwd.li()
                 .lis(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("li");
+        verificationsMultiple("li");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/link.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/link.java
@@ -17,7 +17,7 @@ public class link extends BaseTest {
     @Test
     public void link_functionality() {
 
-        setupExpecations("a");
+        setupExpectationsSingle("a");
 
         FluentWebElements fe = fwd.link()
                 .link(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class link extends BaseTest {
                 .links();
 
         assertThat(fe, notNullValue());
-        verifications("a");
+        verificationsSingle("a");
     }
 
     @Test
     public void links_functionality() {
 
-        setupExpecations2("a");
+        setupExpectationsMultiple("a");
 
         FluentWebElements fe = fwd.link()
                 .links(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("a");
+        verificationsMultiple("a");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/map.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/map.java
@@ -17,7 +17,7 @@ public class map extends BaseTest {
     @Test
     public void map_functionality() {
 
-        setupExpecations("map");
+        setupExpectationsSingle("map");
 
         Internal.BaseFluentWebElements fe = fwd.map()
                 .map(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class map extends BaseTest {
                 .maps();
 
         assertThat(fe, notNullValue());
-        verifications("map");
+        verificationsSingle("map");
     }
 
     @Test
     public void maps_functionality() {
 
-        setupExpecations2("map");
+        setupExpectationsMultiple("map");
 
         Internal.BaseFluentWebElements fe = fwd.map()
                 .maps(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("map");
+        verificationsMultiple("map");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/nav.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/nav.java
@@ -17,7 +17,7 @@ public class nav extends BaseTest {
     @Test
     public void nav_functionality() {
 
-        setupExpecations("nav");
+        setupExpectationsSingle("nav");
 
         FluentWebElements fe = fwd.nav()
                 .nav(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class nav extends BaseTest {
                 .navs();
 
         assertThat(fe, notNullValue());
-        verifications("nav");
+        verificationsSingle("nav");
     }
 
     @Test
     public void navs_functionality() {
 
-        setupExpecations2("nav");
+        setupExpectationsMultiple("nav");
 
         FluentWebElements fe = fwd.nav()
                 .navs(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("nav");
+        verificationsMultiple("nav");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/object.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/object.java
@@ -17,7 +17,7 @@ public class object extends BaseTest {
     @Test
     public void object_functionality() {
 
-        setupExpecations("object");
+        setupExpectationsSingle("object");
 
         FluentWebElements fe = fwd.object()
                 .object(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class object extends BaseTest {
                 .objects();
 
         assertThat(fe, notNullValue());
-        verifications("object");
+        verificationsSingle("object");
     }
 
     @Test
     public void adresss_functionality() {
 
-        setupExpecations2("object");
+        setupExpectationsMultiple("object");
 
         FluentWebElements fe = fwd.object()
                 .objects(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("object");
+        verificationsMultiple("object");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/ol.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/ol.java
@@ -17,7 +17,7 @@ public class ol extends BaseTest {
     @Test
     public void ol_functionality() {
 
-        setupExpecations("ol");
+        setupExpectationsSingle("ol");
 
         FluentWebElements fe = fwd.ol()
                 .ol(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class ol extends BaseTest {
                 .ols();
 
         assertThat(fe, notNullValue());
-        verifications("ol");
+        verificationsSingle("ol");
     }
 
     @Test
     public void ols_functionality() {
 
-        setupExpecations2("ol");
+        setupExpectationsMultiple("ol");
 
         FluentWebElements fe = fwd.ol()
                 .ols(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("ol");
+        verificationsMultiple("ol");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/option.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/option.java
@@ -17,7 +17,7 @@ public class option extends BaseTest {
     @Test
     public void option_functionality() {
 
-        setupExpecations("option");
+        setupExpectationsSingle("option");
 
         FluentWebElements fe = fwd.option()
                 .option(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class option extends BaseTest {
                 .options();
 
         assertThat(fe, notNullValue());
-        verifications("option");
+        verificationsSingle("option");
     }
 
     @Test
     public void options_functionality() {
 
-        setupExpecations2("option");
+        setupExpectationsMultiple("option");
 
         FluentWebElements fe = fwd.option()
                 .options(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("option");
+        verificationsMultiple("option");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/p.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/p.java
@@ -17,7 +17,7 @@ public class p extends BaseTest {
     @Test
     public void p_functionality() {
 
-        setupExpecations("p");
+        setupExpectationsSingle("p");
 
         FluentWebElements fe = fwd.p()
                 .p(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class p extends BaseTest {
                 .ps();
 
         assertThat(fe, notNullValue());
-        verifications("p");
+        verificationsSingle("p");
     }
 
     @Test
     public void ps_functionality() {
 
-        setupExpecations2("p");
+        setupExpectationsMultiple("p");
 
         FluentWebElements fe = fwd.p()
                 .ps(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("p");
+        verificationsMultiple("p");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/pre.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/pre.java
@@ -17,7 +17,7 @@ public class pre extends BaseTest {
     @Test
     public void pre_functionality() {
 
-        setupExpecations("pre");
+        setupExpectationsSingle("pre");
 
         FluentWebElements fe = fwd.pre()
                 .pre(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class pre extends BaseTest {
                 .pres();
 
         assertThat(fe, notNullValue());
-        verifications("pre");
+        verificationsSingle("pre");
     }
 
     @Test
     public void pres_functionality() {
 
-        setupExpecations2("pre");
+        setupExpectationsMultiple("pre");
 
         FluentWebElements fe = fwd.pre()
                 .pres(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("pre");
+        verificationsMultiple("pre");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/select.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/select.java
@@ -33,7 +33,7 @@ public class select extends BaseTest {
     @Test
     public void select_functionality() {
 
-        setupExpecations("select");
+        setupExpectationsSingle("select");
 
         FluentWebElements fe = fwd.select()
                 .select(By.xpath("@foo = 'bar'"))
@@ -41,7 +41,7 @@ public class select extends BaseTest {
                 .selects();
 
         assertThat(fe, notNullValue());
-        verifications("select");
+        verificationsSingle("select");
     }
 
     @Test
@@ -74,14 +74,14 @@ public class select extends BaseTest {
     @Test
     public void selects_functionality() {
 
-        setupExpecations2("select");
+        setupExpectationsMultiple("select");
 
         FluentWebElements fe = fwd.select()
                 .selects(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("select");
+        verificationsMultiple("select");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/span.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/span.java
@@ -17,7 +17,7 @@ public class span extends BaseTest {
     @Test
     public void span_functionality() {
 
-        setupExpecations("span");
+        setupExpectationsSingle("span");
 
         FluentWebElements fe = fwd.span()
                 .span(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class span extends BaseTest {
                 .spans();
 
         assertThat(fe, notNullValue());
-        verifications("span");
+        verificationsSingle("span");
     }
 
     @Test
     public void spans_functionality() {
 
-        setupExpecations2("span");
+        setupExpectationsMultiple("span");
 
         FluentWebElements fe = fwd.span()
                 .spans(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("span");
+        verificationsMultiple("span");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/table.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/table.java
@@ -17,7 +17,7 @@ public class table extends BaseTest {
     @Test
     public void table_functionality() {
 
-        setupExpecations("table");
+        setupExpectationsSingle("table");
 
         FluentWebElements fe = fwd.table()
                 .table(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class table extends BaseTest {
                 .tables();
 
         assertThat(fe, notNullValue());
-        verifications("table");
+        verificationsSingle("table");
     }
 
     @Test
     public void tables_functionality() {
 
-        setupExpecations2("table");
+        setupExpectationsMultiple("table");
 
         FluentWebElements fe = fwd.table()
                 .tables(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("table");
+        verificationsMultiple("table");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/tbody.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/tbody.java
@@ -17,7 +17,7 @@ public class tbody extends BaseTest {
     @Test
     public void tbody_functionality() {
 
-        setupExpecations("tbody");
+        setupExpectationsSingle("tbody");
 
         FluentWebElements fe = fwd.tbody()
                 .tbody(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class tbody extends BaseTest {
                 .tbodys();
 
         assertThat(fe, notNullValue());
-        verifications("tbody");
+        verificationsSingle("tbody");
     }
 
     @Test
     public void adresss_functionality() {
 
-        setupExpecations2("tbody");
+        setupExpectationsMultiple("tbody");
 
         FluentWebElements fe = fwd.tbody()
                 .tbodys(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("tbody");
+        verificationsMultiple("tbody");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/td.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/td.java
@@ -17,7 +17,7 @@ public class td extends BaseTest {
     @Test
     public void td_functionality() {
 
-        setupExpecations("td");
+        setupExpectationsSingle("td");
 
         Internal.BaseFluentWebElements fe = fwd.td()
                 .td(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class td extends BaseTest {
                 .tds();
 
         assertThat(fe, notNullValue());
-        verifications("td");
+        verificationsSingle("td");
     }
 
     @Test
     public void tds_functionality() {
 
-        setupExpecations2("td");
+        setupExpectationsMultiple("td");
 
         Internal.BaseFluentWebElements fe = fwd.td()
                 .tds(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("td");
+        verificationsMultiple("td");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/textarea.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/textarea.java
@@ -17,7 +17,7 @@ public class textarea extends BaseTest {
     @Test
     public void textarea_functionality() {
 
-        setupExpecations("textarea");
+        setupExpectationsSingle("textarea");
 
         FluentWebElements fe = fwd.textarea()
                 .textarea(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class textarea extends BaseTest {
                 .textareas();
 
         assertThat(fe, notNullValue());
-        verifications("textarea");
+        verificationsSingle("textarea");
     }
 
     @Test
     public void textareas_functionality() {
 
-        setupExpecations2("textarea");
+        setupExpectationsMultiple("textarea");
 
         FluentWebElements fe = fwd.textarea()
                 .textareas(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("textarea");
+        verificationsMultiple("textarea");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/th.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/th.java
@@ -17,7 +17,7 @@ public class th extends BaseTest {
     @Test
     public void th_functionality() {
 
-        setupExpecations("th");
+        setupExpectationsSingle("th");
 
         FluentWebElements fe = fwd.th()
                 .th(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class th extends BaseTest {
                 .ths();
 
         assertThat(fe, notNullValue());
-        verifications("th");
+        verificationsSingle("th");
     }
 
     @Test
     public void ths_functionality() {
 
-        setupExpecations2("th");
+        setupExpectationsMultiple("th");
 
         FluentWebElements fe = fwd.th()
                 .ths(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("th");
+        verificationsMultiple("th");
 
     }
 

--- a/java/src/test/java/org/seleniumhq/selenium/fluent/elements/tr.java
+++ b/java/src/test/java/org/seleniumhq/selenium/fluent/elements/tr.java
@@ -17,7 +17,7 @@ public class tr extends BaseTest {
     @Test
     public void tr_functionality() {
 
-        setupExpecations("tr");
+        setupExpectationsSingle("tr");
 
         FluentWebElements fe = fwd.tr()
                 .tr(By.xpath("@foo = 'bar'"))
@@ -25,20 +25,20 @@ public class tr extends BaseTest {
                 .trs();
 
         assertThat(fe, notNullValue());
-        verifications("tr");
+        verificationsSingle("tr");
     }
 
     @Test
     public void trs_functionality() {
 
-        setupExpecations2("tr");
+        setupExpectationsMultiple("tr");
 
         FluentWebElements fe = fwd.tr()
                 .trs(By.name("qux"));
 
         assertThat(fe, notNullValue());
 
-        verifications2("tr");
+        verificationsMultiple("tr");
 
     }
 


### PR DESCRIPTION
"My way to implement" the generic tag support proposed by the following issue https://github.com/SeleniumHQ/fluent-selenium/issues/5.

UT updated & checked.