### PR TITLE
Exposing support for unordered lists (ul)

### DIFF
--- a/java/src/main/java/org/seleniumhq/selenium/fluent/FluentWebElement.java
+++ b/java/src/main/java/org/seleniumhq/selenium/fluent/FluentWebElement.java
@@ -595,6 +595,18 @@ public class FluentWebElement extends Internal.BaseFluentWebElement {
     }
 
     @Override
+    public FluentWebElement ul() { return (FluentWebElement) super.ul(); }
+
+    @Override
+    public FluentWebElement ul(By by) { return (FluentWebElement) super.ul(by); }
+
+    @Override
+    public FluentWebElements uls() { return (FluentWebElements) super.uls(); }
+
+    @Override
+    public FluentWebElements uls(By by) { return (FluentWebElements) super.uls(by); }
+
+    @Override
     public FluentWebElements lis() {
         return (FluentWebElements) super.lis();
     }


### PR DESCRIPTION
My sites use the UL tag  (unordered list) heavily, however we were not able to access them via the FluentWebElement.
 
The internal classes already support the UL tag, it was only missing from the FluentWebElement and is therefore not exposed.  I have simply added the necessary calls to expose this tag in the interface.
